### PR TITLE
Moved case transformation before initialization check

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2922,10 +2922,11 @@ def open(fp, mode="r", formats=None):
 
     def _open_core(fp, filename, prefix, formats):
         for i in formats:
+            i = i.upper()
             if i not in OPEN:
                 init()
             try:
-                factory, accept = OPEN[i.upper()]
+                factory, accept = OPEN[i]
                 result = not accept or accept(prefix)
                 if type(result) in [str, bytes]:
                     accept_warnings.append(result)


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/5250

Because the check at https://github.com/python-pillow/Pillow/blob/0c1675a14390f19cef56e4d8cc1ab93d7ed74c95/src/PIL/Image.py#L2925 doesn't use the uppercase version of `i` at the moment.