### PR TITLE
Replaced non-existent extension with txt

### DIFF
--- a/Tests/test_file_ppm.py
+++ b/Tests/test_file_ppm.py
@@ -51,7 +51,7 @@ def test_pnm(tmp_path):
 
 
 def test_not_ppm(tmp_path):
-    path = str(tmp_path / "temp.djvurle")
+    path = str(tmp_path / "temp.txt")
     with open(path, "wb") as f:
         f.write(b"PyInvalid")
 
@@ -70,7 +70,7 @@ def test_header_with_comments(tmp_path):
 
 
 def test_nondecimal_header(tmp_path):
-    path = str(tmp_path / "temp.djvurle")
+    path = str(tmp_path / "temp.txt")
     with open(path, "wb") as f:
         f.write(b"P6\n128\x00")
 
@@ -80,7 +80,7 @@ def test_nondecimal_header(tmp_path):
 
 
 def test_token_too_long(tmp_path):
-    path = str(tmp_path / "temp.djvurle")
+    path = str(tmp_path / "temp.txt")
     with open(path, "wb") as f:
         f.write(b"P6\n 0123456789")
 
@@ -90,7 +90,7 @@ def test_token_too_long(tmp_path):
 
 
 def test_too_many_colors(tmp_path):
-    path = str(tmp_path / "temp.djvurle")
+    path = str(tmp_path / "temp.txt")
     with open(path, "wb") as f:
         f.write(b"P6\n1 1\n1000\n")
 


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/pull/5121

This might just be me - I presume "djvurle" is a random series of characters? If the intention is for it to be something other than "ppm", this PR changes it to "txt", to avoid the impression that "djvurle" is meaningful.